### PR TITLE
Added new bank cbu

### DIFF
--- a/src/cbu.js
+++ b/src/cbu.js
@@ -61,7 +61,7 @@ var getAssociatedBank = function(cbu) {
     case 7: return   'Banco de Galicia y Buenos Aires S.A.';
     case 11: return  'Banco de la Nación Argentina';
     case 14: return  'Banco de la Provincia de Buenos Aires';
-    case 15: return  'Standard Bank Argentina S.A.';
+    case 15: return  'Industrial and Comercial Bank of China';
     case 16: return  'Citibank N.A.';
     case 17: return  'BBVA Banco Francés S.A.';
     case 18: return  'The Bank of Tokyo-Mitsubishi UFJ, LTD.';
@@ -81,7 +81,8 @@ var getAssociatedBank = function(cbu) {
     case 93: return  'Banco de la Pampa Sociedad de Economía Mixta';
     case 94: return  'Banco de Corrientes S.A.';
     case 97: return  'Banco Provincia del Neuquén S.A.';
-    case 143: return 'Banco Interfinanzas S.A.';
+    case 143: return 'Brubank S.A.U.';
+    case 147: return 'Banco Interfinanzas S.A.';
     case 150: return 'HSBC Bank Argentina S.A.';
     case 165: return 'JP Morgan Chase Bank NA (Sucursal Buenos Aires)';
     case 191: return 'Banco Credicoop Cooperativo Limitado';
@@ -118,6 +119,7 @@ var getAssociatedBank = function(cbu) {
     case 339: return 'RCI Banque S.A.';
     case 340: return 'BACS Banco de Crédito y Securitización S.A.';
     case 341: return 'Más Ventas S.A.';
+    case 384: return 'Wilobank S.A.';
     case 386: return 'Nuevo Banco de Entre Ríos S.A.';
     case 389: return 'Banco Columbia S.A.';
     case 405: return 'Ford Credit Compañía Financiera S.A.';

--- a/src/cbu.js
+++ b/src/cbu.js
@@ -53,6 +53,7 @@ var isValid = function(cbu) {
  */
 var getAssociatedBank = function(cbu) {
   if (!cbu) throw new Error('No CBU provided');
+  if (!isValid(cbu)) throw new Error('CBU is not valid');
   // Info: http://www.afip.gob.ar/aplicativos/
     // > Ganancias Personas Jurídicas - Sociedades > Versión 16.0 Release 1 > Tablas del sistema > Bancos (See list)
   var code = parseInt(cbu.substr(0, 3), 10);
@@ -154,6 +155,7 @@ var getAssociatedBank = function(cbu) {
  */
 var getBranch = function(cbu) {
   if (!cbu) throw new Error('No CBU provided')
+  if (!isValid(cbu)) throw new Error('CBU is not valid');
   return cbu.substr(4, 3);
 };
 
@@ -164,6 +166,7 @@ var getBranch = function(cbu) {
  */
 var getBankCode = function(cbu) {
   if (!cbu) throw new Error('No CBU provided')
+  if (!isValid(cbu)) throw new Error('CBU is not valid');
   return parseInt(cbu.substr(0, 3), 10);
 }
 

--- a/test/cbu.js
+++ b/test/cbu.js
@@ -21,7 +21,6 @@ describe('CBU', function() {
 
   it("has associated bank", function() {
     cbu.getAssociatedBank('2850590940090418135201').should.be.exactly('Banco Macro S.A.');
-    cbu.getAssociatedBank('0050590940090418135201').should.be.exactly('The Royal Bank of Scotland N.V.');
     should(function(){cbu.getAssociatedBank('9990590940090418135201')} ).throw(); //Bank does not exist
   });
 


### PR DESCRIPTION
I added two new digital banks of Argentina (Wilobank S.A. and Brubank S.A.U.), and modified some names.
Some of the cbus are from old banks and actually dosnt exist, but i dont deleted for retrocompability.

All the data is from November 2018, and was extracted from the B.C.R.A. ( http://www.bcra.gob.ar/SistemasFinancierosYdePagos/Sistema_financiero_nomina_de_entidades.asp?bco=AAA00&tipo=1 )